### PR TITLE
small fixups v2: optimize build and fixed mtu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM docker.io/library/node:18-alpine@sha256:435dcad253bb5b7f347ebc69c8cc52de7c9
 # Copy Web UI
 COPY src/ /app/
 WORKDIR /app
-RUN npm config set fund false && npm ci --production
+RUN npm config set fund false && npm ci --omit=dev
 
 # Copy build result to a new image.
 # This saves a lot of disk space.

--- a/src/config.js
+++ b/src/config.js
@@ -10,7 +10,7 @@ module.exports.WG_PATH = process.env.WG_PATH || '/etc/wireguard/';
 module.exports.WG_DEVICE = process.env.WG_DEVICE || 'eth0';
 module.exports.WG_HOST = process.env.WG_HOST;
 module.exports.WG_PORT = process.env.WG_PORT || 51820;
-module.exports.WG_MTU = process.env.WG_MTU || null;
+module.exports.WG_MTU = process.env.WG_MTU || 1420;
 module.exports.WG_PERSISTENT_KEEPALIVE = process.env.WG_PERSISTENT_KEEPALIVE || 0;
 module.exports.WG_DEFAULT_ADDRESS = process.env.WG_DEFAULT_ADDRESS || '10.8.0.x';
 module.exports.WG_DEFAULT_DNS = typeof process.env.WG_DEFAULT_DNS === 'string'


### PR DESCRIPTION
Is the same as `--production`, this just avoids a build warning regarding the switch to: `--omit=dev`.
MTU is set to wireguards default when not specified on docker-compose file.